### PR TITLE
add storageClassName to pvc as well

### DIFF
--- a/kubernetes/persistent-volume-claim.yml
+++ b/kubernetes/persistent-volume-claim.yml
@@ -11,3 +11,4 @@ spec:
     requests:
       storage: 2Gi
   volumeName: postgres-pv
+  storageClassName: standard


### PR DESCRIPTION
otherwise, the pvc won't come up.  Instead, we get the error: 
```  Warning    VolumeMismatch     3m51s (x323 over 84m)  persistentvolume-controller  Cannot bind to requested volume "postgres-pv": storageClassName does not match```