### PR TITLE
Convert to k8s version 1.16 APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,3 +164,32 @@ $ kubectl create -f ./kubernetes/vue-service.yml
 ```
 
 Try it out at [http://hello.world/](http://hello.world/).
+
+## Upgrading Kubernetes versions
+
+The original project was built using Kubernetes 1.13. 
+Some of the API's have been deprecated and do not work with version 1.16. 
+
+`kubectl` can be used to convert. E.g.:
+
+```sh
+kubectl convert -f ./kubernetes/flask-deployment.yml.yml --output-version apps/v1
+```
+
+For example, the `flask-deployment.yml` went from:
+
+```yaml
+apiVersion: extensions/v1beta1
+kind: Deployment
+...
+```
+
+to:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+...
+```
+
+A number of new default values are added in the conversion too.

--- a/kubernetes/flask-deployment.yml
+++ b/kubernetes/flask-deployment.yml
@@ -1,32 +1,49 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: flask
   labels:
     name: flask
+  name: flask
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: flask
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:
         app: flask
     spec:
       containers:
-      - name: flask
-        image: mjhea0/flask-kubernetes:latest
-        env:
+      - env:
         - name: FLASK_ENV
-          value: "development"
+          value: development
         - name: APP_SETTINGS
-          value: "project.config.DevelopmentConfig"
+          value: project.config.DevelopmentConfig
         - name: POSTGRES_USER
           valueFrom:
             secretKeyRef:
-              name: postgres-credentials
               key: user
+              name: postgres-credentials
         - name: POSTGRES_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: postgres-credentials
               key: password
+              name: postgres-credentials
+        image: fingertip/flask-kubernetes:latest
+        imagePullPolicy: Always
+        name: flask
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
       restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status: {}

--- a/kubernetes/postgres-deployment.yml
+++ b/kubernetes/postgres-deployment.yml
@@ -1,35 +1,54 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: postgres
+  creationTimestamp: null
   labels:
     name: database
+  name: postgres
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      service: postgres
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
+      creationTimestamp: null
       labels:
         service: postgres
     spec:
       containers:
-      - name: postgres
+      - env:
+        - name: POSTGRES_USER
+          valueFrom:
+            secretKeyRef:
+              key: user
+              name: postgres-credentials
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: postgres-credentials
         image: postgres:10.4-alpine
-        env:
-          - name: POSTGRES_USER
-            valueFrom:
-              secretKeyRef:
-                name: postgres-credentials
-                key: user
-          - name: POSTGRES_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: postgres-credentials
-                key: password
+        imagePullPolicy: IfNotPresent
+        name: postgres
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
         volumeMounts:
-          - name: postgres-volume-mount
-            mountPath: /var/lib/postgresql/data
+        - mountPath: /var/lib/postgresql/data
+          name: postgres-volume-mount
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
       volumes:
       - name: postgres-volume-mount
         persistentVolumeClaim:
           claimName: postgres-pvc
-      restartPolicy: Always
+status: {}

--- a/kubernetes/vue-deployment.yml
+++ b/kubernetes/vue-deployment.yml
@@ -1,17 +1,34 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: vue
   labels:
     name: vue
+  name: vue
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: vue
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:
         app: vue
     spec:
       containers:
-      - name: vue
-        image: mjhea0/vue-kubernetes:latest
+      - image: fingertip/vue-kubernetes:latest
+        imagePullPolicy: Always
+        name: vue
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
       restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status: {}


### PR DESCRIPTION
When I used this project I found it generated errors as I am using Kubernetes version v1.16.2.
Using `kubectl convert` I made changed that fixed the errors and it now runs great on v1.16.

PS. Thanks for the project. It has allowed me to jump-start my experimentation.